### PR TITLE
test: test case for the root plex uses the name as the container's key

### DIFF
--- a/test/end-spread.test.ts
+++ b/test/end-spread.test.ts
@@ -1,0 +1,57 @@
+import * as pull from 'pull-stream'
+import { Plex, Channel, wrap, PlexEvent } from '../src'
+import { window } from '@jacobbubu/pull-window'
+
+describe('pull-plex', () => {
+  it('end-spread', (done) => {
+    function flatArray() {
+      const buffer: any[] = []
+      return (source: pull.Source<any[]>) => {
+        return (end: pull.Abort, cb: pull.Source<any>) => {
+          if (buffer.length > 0) {
+            cb(null, buffer.shift())
+          } else {
+            source(end, (end, list) => {
+              list?.forEach((e) => buffer.push(e))
+              cb(null, buffer.shift())
+            })
+          }
+        }
+      }
+    }
+    function logThrough(tag: string) {
+      return (source: pull.Source<PlexEvent>) => {
+        return (abort: pull.Abort, cb: pull.SourceCallback<PlexEvent>) => {
+          source(abort, (end, data) => {
+            console.log(`${tag}: ${data}`)
+            cb(end, data)
+          })
+        }
+      }
+    }
+
+    const a = new Plex('a')
+    const b = new Plex('b')
+
+    pull(a.source, window.recent<any, any[]>(null, 10), flatArray(), logThrough('a->b'), b.sink)
+    pull(b.source, window.recent<any, any[]>(null, 10), flatArray(), logThrough('b->a'), a.sink)
+
+    const subPlexOnA1 = a.createPlex('subPlexOnA')
+    subPlexOnA1.on('close', (plex: Plex) => {
+      console.log('subPlexOnA1 closed')
+    })
+    subPlexOnA1.end(true)
+
+    const subPlexOnA2 = a.createPlex('subPlexOnA')
+    subPlexOnA2.on('close', (plex: Plex) => {
+      console.log('subPlexOnA2 closed, this is unreachable')
+      // throw Error("unreachable")
+    })
+
+    console.log(Date())
+    setTimeout(() => {
+      console.log(Date())
+      done()
+    }, 100)
+  })
+})


### PR DESCRIPTION
当遇到一下场景会出问题：
plex1 link plex2
1. plex1 create subPlex[a]
2. subPlex[a] closed
3. plex1 create subPlex[a] again
4. any unreliable factor makes plex2 receive the above 3 event in a trunk
5. plex2 will send the RemotePlexEnd to plex1
6. plex1 closed the new subPlex[a]

### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes #[Add issue number here.]

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
_Describe what this Pull Request does_
